### PR TITLE
Added PROCESS_VM_OPERATION to OpenProcess

### DIFF
--- a/src/windows/mem.rs
+++ b/src/windows/mem.rs
@@ -9,7 +9,7 @@ use super::{conv_err, Handle};
 use windows::core::HRESULT;
 use windows::Win32::System::Diagnostics::Debug::{ReadProcessMemory, WriteProcessMemory};
 use windows::Win32::System::Threading::{
-    OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, PROCESS_VM_WRITE, PROCESS_VM_OPERATION,
+    OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_OPERATION, PROCESS_VM_READ, PROCESS_VM_WRITE,
 };
 
 #[derive(Clone)]
@@ -21,7 +21,10 @@ impl ProcessVirtualMemory {
     pub fn try_new(info: &ProcessInfo) -> Result<Self> {
         let handle: Arc<Handle> = unsafe {
             OpenProcess(
-                PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION,
+                PROCESS_VM_READ
+                    | PROCESS_VM_WRITE
+                    | PROCESS_VM_OPERATION
+                    | PROCESS_QUERY_INFORMATION,
                 false,
                 info.pid as _,
             )

--- a/src/windows/mem.rs
+++ b/src/windows/mem.rs
@@ -9,7 +9,7 @@ use super::{conv_err, Handle};
 use windows::core::HRESULT;
 use windows::Win32::System::Diagnostics::Debug::{ReadProcessMemory, WriteProcessMemory};
 use windows::Win32::System::Threading::{
-    OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, PROCESS_VM_WRITE,
+    OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, PROCESS_VM_WRITE, PROCESS_VM_OPERATION,
 };
 
 #[derive(Clone)]
@@ -21,7 +21,7 @@ impl ProcessVirtualMemory {
     pub fn try_new(info: &ProcessInfo) -> Result<Self> {
         let handle: Arc<Handle> = unsafe {
             OpenProcess(
-                PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_INFORMATION,
+                PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION,
                 false,
                 info.pid as _,
             )


### PR DESCRIPTION
Hello everyone,

ive added PROCESS_VM_OPERATION to the handle because writing can silently fail without it.
Its also mentioned in the [Docs](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-writeprocessmemory#parameters).

Sincerely,
Papanoob